### PR TITLE
When configUrl is used but no config was found should result in error

### DIFF
--- a/__tests__/ConfigHelper.test.ts
+++ b/__tests__/ConfigHelper.test.ts
@@ -28,6 +28,18 @@ const mockDataServer = {
   },
 };
 
+const mockDataServerError = {
+  host: "outlook",
+  CoercionType,
+  context: {
+    mailbox: {
+      userProfile: {
+        emailAddress: "test@controoll.test",
+      },
+    },
+  },
+};
+
 const nullConfig: Config = {
   baseUrl: "null",
   meetings: [],
@@ -45,7 +57,7 @@ describe('Test ConfigHelper', () => {
       body: JSON.stringify(testConfig)
     });
     let l_config: Config = nullConfig;
-    getConfigXHR((config) => {
+    getConfigXHR((config, e) => {
       l_config = config;
     }, "");
     expect(l_config).toEqual(testConfig);
@@ -58,10 +70,28 @@ describe('Test ConfigHelper', () => {
       body: JSON.stringify(testConfig)
     });
     let l_config: Config = nullConfig;
-    getConfigXHR((config) => {
+    getConfigXHR((config, e) => {
       l_config = config;
     });
     expect(l_config).toEqual({});
+  });
+
+  it('should get empty config, error', async () => {
+    const userProfile = new OfficeMockObject(mockDataServerError);
+    global.Office = userProfile as any;
+    mock.get('controoll.test/config.json', {
+      body: "Error file not found",
+      status: 404,
+      reason: "Not found"
+    });
+    let l_config: Config = nullConfig;
+    let error: string = "";
+    getConfigXHR((config, e) => {
+      l_config = config;
+      error = e
+    }, "");
+    expect(l_config).toEqual({});
+    expect(error).toEqual("Error fetching config: controoll.test/config.json<br><br>Error code: 404<br>Error message: Error file not found<br>");
   });
 
   it('fetch meeting information', async () => {

--- a/__tests__/OfficeCallHandler.test.ts
+++ b/__tests__/OfficeCallHandler.test.ts
@@ -147,7 +147,7 @@ describe("Connection test to server", () => {
     let body: string = "";
     let opt: Office.CoercionType = Office.CoercionType.Html;
 
-    await addMeeting("StandardMeeting", config);
+    await addMeeting("StandardMeeting", config, "");
 
     Office.context.mailbox.item.location.getAsync((r) => { location = r.value });
     Office.context.mailbox.item.body.getAsync(opt, (r) => { body = r.value });
@@ -171,7 +171,7 @@ describe("Connection test to server", () => {
     let body: string = "";
     let opt: Office.CoercionType = Office.CoercionType.Html;
 
-    await addMeeting("StandardMeeting", config);
+    await addMeeting("StandardMeeting", config, "");
 
     Office.context.mailbox.item.location.getAsync((r) => { location = r.value });
     Office.context.mailbox.item.body.getAsync(opt, (r) => { body = r.value });

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -17,7 +17,7 @@ let addinConfig: AddinConfig = a_config;
 
 const addJitsiLink = (event: Office.AddinCommands.Event, name: string) => {
   try {
-    loadConfig((config: Config) => addMeeting(name, config, event), addinConfig.configUrl);
+    loadConfig((config: Config, error: string) => addMeeting(name, config, error, event), addinConfig.configUrl);
   } catch (error) {
     console.log(error);
     return;

--- a/src/utils/ConfigHelper.ts
+++ b/src/utils/ConfigHelper.ts
@@ -7,7 +7,7 @@
 import { Config } from "../models/Config";
 import DefaultConfig from "../../config.json";
 
-export const getConfigXHR = function (callback: (config: Config) => void, configUrl?: string) {
+export const getConfigXHR = function (callback: (config: Config, error: string) => void, configUrl?: string) {
   let domain: string | null = getDomain();
   const xhr = new XMLHttpRequest();
   if (configUrl !== undefined) {
@@ -15,9 +15,12 @@ export const getConfigXHR = function (callback: (config: Config) => void, config
       xhr.open("GET", configUrl + domain + "/config.json", false);
       xhr.onreadystatechange = function () {
         if (xhr.readyState == 4 && xhr.status == 200) {
-          callback(JSON.parse(xhr.responseText) as Config);
+          callback(JSON.parse(xhr.responseText) as Config, "");
         } else {
-          callback(DefaultConfig as Config);
+          let error: string = "Error fetching config: " + configUrl + domain + "/config.json<br><br>";
+          error += "Error code: " + xhr.status.toString() + "<br>";
+          error += "Error message: " + xhr.responseText + "<br>";
+          callback(DefaultConfig as Config, error);
         }
       };
       xhr.send();
@@ -25,7 +28,7 @@ export const getConfigXHR = function (callback: (config: Config) => void, config
       console.log("getConfig - No domain found.");
     }
   } else {
-    callback(DefaultConfig as Config);
+    callback(DefaultConfig as Config, "");
   }
 };
 
@@ -40,10 +43,10 @@ const getDomain = (): string | null => {
   }
 };
 
-export const loadConfig = function (callback: (config: Config) => void, configUrl?: string) {
+export const loadConfig = function (callback: (config: Config, error: string) => void, configUrl?: string) {
   console.log(configUrl);
-  getConfigXHR((config) => {
-    callback(config);
+  getConfigXHR((config, e) => {
+    callback(config, e);
   }, configUrl);
 };
 

--- a/src/utils/DOMHelper.ts
+++ b/src/utils/DOMHelper.ts
@@ -11,9 +11,14 @@ import { getJitsiUrl } from "./URLHelper";
 const DIV_ID_JITSI = "jitsi-link";
 
 export const combineBodyWithJitsiDiv = (body: string, config: Config, index?: number, subject?: string): string => {
-  const jitsiUrl = getJitsiUrl(config, index, subject);
+  return combineBodyWithChosenDiv(body, getJitsiLinkDiv(getJitsiUrl(config, index, subject), config));
+};
 
-  const linkDOM = getJitsiLinkDiv(jitsiUrl, config);
+export const combineBodyWithErrorDiv = (body: string, error: string): string => {
+  return combineBodyWithChosenDiv(body, error);
+};
+
+export const combineBodyWithChosenDiv = (body: string, linkDOM: string): string => {
   const parser = new DOMParser();
 
   const bodyString = `

--- a/src/utils/OfficeCallHandler.ts
+++ b/src/utils/OfficeCallHandler.ts
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT
 
 import { Config } from "../models/Config";
-import { bodyHasJitsiLink, combineBodyWithJitsiDiv, overwriteJitsiLinkDiv } from "../utils/DOMHelper";
+import { bodyHasJitsiLink, combineBodyWithJitsiDiv, overwriteJitsiLinkDiv, combineBodyWithErrorDiv } from "../utils/DOMHelper";
 import { getMeetingConfig } from "../utils/ConfigHelper";
 
 /* global Office, console */
@@ -48,7 +48,7 @@ const setLocation = async (config: Config) => {
 
 export const setLocationTest = { setLocation };
 
-export const addMeeting = async (name: string, config: Config, event?: Office.AddinCommands.Event) => {
+export const addMeeting = async (name: string, config: Config, error: string, event?: Office.AddinCommands.Event) => {
   let index: number = getMeetingConfig(config, name);
 
   Office.context.mailbox.item.body.getAsync(Office.CoercionType.Html, (result) => {
@@ -60,8 +60,12 @@ export const addMeeting = async (name: string, config: Config, event?: Office.Ad
       Office.context.mailbox.item.subject.getAsync((subject) => {
         const parser = new DOMParser();
         const htmlDoc = parser.parseFromString(result.value, "text/html");
-
-        const bodyDOM = bodyHasJitsiLink(result.value, config) ? overwriteJitsiLinkDiv(htmlDoc, config, index, subject.value) : combineBodyWithJitsiDiv(result.value, config, index, subject.value);
+        let bodyDOM: string = "";
+        if (error !== "") {
+          bodyDOM = combineBodyWithErrorDiv(result.value, error);
+        } else {
+          bodyDOM = bodyHasJitsiLink(result.value, config) ? overwriteJitsiLinkDiv(htmlDoc, config, index, subject.value) : combineBodyWithJitsiDiv(result.value, config, index, subject.value);
+        }
         setData(htmlDoc.head.innerHTML + bodyDOM, event);
         setLocation(config);
       });


### PR DESCRIPTION
# Pull Request Description

Please include a summary of the change and which issue is fixed or added.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

When using configUrl in config.json but the plugin does not find any config it should present an error for the end user.
This code will combine an error message with the default footer text. 

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
